### PR TITLE
Improve keyboard focus visibility

### DIFF
--- a/until.js
+++ b/until.js
@@ -1,0 +1,61 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = until;
+
+var _whilst = require('./whilst.js');
+
+var _whilst2 = _interopRequireDefault(_whilst);
+
+var _wrapAsync = require('./internal/wrapAsync.js');
+
+var _wrapAsync2 = _interopRequireDefault(_wrapAsync);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Repeatedly call `iteratee` until `test` returns `true`. Calls `callback` when
+ * stopped, or an error occurs. `callback` will be passed an error and any
+ * arguments passed to the final `iteratee`'s callback.
+ *
+ * The inverse of [whilst]{@link module:ControlFlow.whilst}.
+ *
+ * @name until
+ * @static
+ * @memberOf module:ControlFlow
+ * @method
+ * @see [async.whilst]{@link module:ControlFlow.whilst}
+ * @category Control Flow
+ * @param {AsyncFunction} test - asynchronous truth test to perform before each
+ * execution of `iteratee`. Invoked with (callback).
+ * @param {AsyncFunction} iteratee - An async function which is called each time
+ * `test` fails. Invoked with (callback).
+ * @param {Function} [callback] - A callback which is called after the test
+ * function has passed and repeated execution of `iteratee` has stopped. `callback`
+ * will be passed an error and any arguments passed to the final `iteratee`'s
+ * callback. Invoked with (err, [results]);
+ * @returns {Promise} a promise, if a callback is not passed
+ *
+ * @example
+ * const results = []
+ * let finished = false
+ * async.until(function test(cb) {
+ *     cb(null, finished)
+ * }, function iter(next) {
+ *     fetchPage(url, (err, body) => {
+ *         if (err) return next(err)
+ *         results = results.concat(body.objects)
+ *         finished = !!body.next
+ *         next(err)
+ *     })
+ * }, function done (err) {
+ *     // all pages have been fetched
+ * })
+ */
+function until(test, iteratee, callback) {
+  const _test = (0, _wrapAsync2.default)(test);
+  return (0, _whilst2.default)(cb => _test((err, truth) => cb(err, !truth)), iteratee, callback);
+}
+module.exports = exports['default'];


### PR DESCRIPTION
Enhances accessibility by making focus outlines more visible for keyboard users. Updates focus styles for buttons and links to use a 2px solid accent color with :focus-visible and adds a slight outline-offset to avoid layout shift.