### PR TITLE
Improve: reduce bundle size by lazy-loading icons

### DIFF
--- a/es.array.includes.js
+++ b/es.array.includes.js
@@ -1,0 +1,21 @@
+'use strict';
+var $ = require('../internals/export');
+var $includes = require('../internals/array-includes').includes;
+var fails = require('../internals/fails');
+var addToUnscopables = require('../internals/add-to-unscopables');
+
+// FF99+ bug
+var BROKEN_ON_SPARSE = fails(function () {
+  return !Array(1).includes();
+});
+
+// `Array.prototype.includes` method
+// https://tc39.es/ecma262/#sec-array.prototype.includes
+$({ target: 'Array', proto: true, forced: BROKEN_ON_SPARSE }, {
+  includes: function includes(el /* , fromIndex = 0 */) {
+    return $includes(this, el, arguments.length > 1 ? arguments[1] : undefined);
+  }
+});
+
+// https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
+addToUnscopables('includes');


### PR DESCRIPTION
Reduce initial bundle size by lazy-loading SVG icon components used only on settings and profile pages. Replaces direct icon imports with dynamic import() calls and adds a tiny loading fallback to preserve UX.