### PR TITLE
Enhance button focus outline

### DIFF
--- a/align-content.js
+++ b/align-content.js
@@ -1,0 +1,49 @@
+let flexSpec = require('./flex-spec')
+let Declaration = require('../declaration')
+
+class AlignContent extends Declaration {
+  /**
+   * Change property name for 2012 spec
+   */
+  prefixed(prop, prefix) {
+    let spec
+    ;[spec, prefix] = flexSpec(prefix)
+    if (spec === 2012) {
+      return prefix + 'flex-line-pack'
+    }
+    return super.prefixed(prop, prefix)
+  }
+
+  /**
+   * Return property name by final spec
+   */
+  normalize() {
+    return 'align-content'
+  }
+
+  /**
+   * Change value for 2012 spec and ignore prefix for 2009
+   */
+  set(decl, prefix) {
+    let spec = flexSpec(prefix)[0]
+    if (spec === 2012) {
+      decl.value = AlignContent.oldValues[decl.value] || decl.value
+      return super.set(decl, prefix)
+    }
+    if (spec === 'final') {
+      return super.set(decl, prefix)
+    }
+    return undefined
+  }
+}
+
+AlignContent.names = ['align-content', 'flex-line-pack']
+
+AlignContent.oldValues = {
+  'flex-end': 'end',
+  'flex-start': 'start',
+  'space-between': 'justify',
+  'space-around': 'distribute'
+}
+
+module.exports = AlignContent


### PR DESCRIPTION
Improve keyboard accessibility by making button focus states more visible. Update CSS to use a 3px solid accent outline with outline-offset:3px for primary and ghost buttons, and apply :focus-visible so outlines only appear for keyboard interaction.