### PR TITLE
Improve button focus outline

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (options = {}) => options.Promise || require('bluebird')


### PR DESCRIPTION
Improve keyboard accessibility by making button focus outlines visible and consistent across browsers. Updated CSS to use :focus-visible, add outline-offset and a 2px high-contrast outline, and remove box-shadow-only focus styles to ensure a clear focus state.