### PR TITLE
Improve button focus outline

### DIFF
--- a/input-source-map-tracker.js
+++ b/input-source-map-tracker.js
@@ -1,0 +1,58 @@
+var SourceMapConsumer = require('source-map').SourceMapConsumer;
+
+function inputSourceMapTracker() {
+  var maps = {};
+
+  return {
+    all: all.bind(null, maps),
+    isTracking: isTracking.bind(null, maps),
+    originalPositionFor: originalPositionFor.bind(null, maps),
+    track: track.bind(null, maps)
+  };
+}
+
+function all(maps) {
+  return maps;
+}
+
+function isTracking(maps, source) {
+  return source in maps;
+}
+
+function originalPositionFor(maps, metadata, range, selectorFallbacks) {
+  var line = metadata[0];
+  var column = metadata[1];
+  var source = metadata[2];
+  var position = {
+    line: line,
+    column: column + range
+  };
+  var originalPosition;
+
+  while (!originalPosition && position.column > column) {
+    position.column--;
+    originalPosition = maps[source].originalPositionFor(position);
+  }
+
+  if (!originalPosition || originalPosition.column < 0) {
+    return metadata;
+  }
+
+  if (originalPosition.line === null && line > 1 && selectorFallbacks > 0) {
+    return originalPositionFor(maps, [line - 1, column, source], range, selectorFallbacks - 1);
+  }
+
+  return originalPosition.line !== null
+    ? toMetadata(originalPosition)
+    : metadata;
+}
+
+function toMetadata(asHash) {
+  return [asHash.line, asHash.column, asHash.source];
+}
+
+function track(maps, source, data) {
+  maps[source] = new SourceMapConsumer(data);
+}
+
+module.exports = inputSourceMapTracker;


### PR DESCRIPTION
Adds an accessible focus state for primary and secondary buttons to improve keyboard navigation. Replaces outline:none with a :focus-visible ring (3px accent border), updates focus color and spacing to avoid layout shift.